### PR TITLE
upgrade: laravel 11/12 support with CI

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,0 +1,68 @@
+name: Tests
+
+on:
+  push:
+    branches: [trunk, laravel-11]
+  pull_request:
+    branches: [trunk]
+
+jobs:
+  tests:
+    runs-on: ubuntu-latest
+
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          # Laravel 10 — PHP 8.1, 8.2, 8.3
+          - php: '8.1'
+            laravel: '10.*'
+            testbench: '8.*'
+          - php: '8.2'
+            laravel: '10.*'
+            testbench: '8.*'
+          - php: '8.3'
+            laravel: '10.*'
+            testbench: '8.*'
+
+          # Laravel 11 — PHP 8.2, 8.3, 8.4
+          - php: '8.2'
+            laravel: '11.*'
+            testbench: '9.*'
+          - php: '8.3'
+            laravel: '11.*'
+            testbench: '9.*'
+          - php: '8.4'
+            laravel: '11.*'
+            testbench: '9.*'
+
+          # Laravel 12 — PHP 8.2, 8.3, 8.4
+          - php: '8.2'
+            laravel: '12.*'
+            testbench: '10.*'
+          - php: '8.3'
+            laravel: '12.*'
+            testbench: '10.*'
+          - php: '8.4'
+            laravel: '12.*'
+            testbench: '10.*'
+
+    name: PHP ${{ matrix.php }} / Laravel ${{ matrix.laravel }}
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Setup PHP
+        uses: shivammathur/setup-php@v2
+        with:
+          php-version: ${{ matrix.php }}
+          extensions: dom, curl, libxml, mbstring, zip, pdo, sqlite, pdo_sqlite
+          coverage: none
+
+      - name: Install dependencies
+        run: |
+          composer require "illuminate/support:${{ matrix.laravel }}" "illuminate/contracts:${{ matrix.laravel }}" "illuminate/database:${{ matrix.laravel }}" "orchestra/testbench:${{ matrix.testbench }}" --no-interaction --no-update
+          composer update --prefer-dist --no-interaction
+
+      - name: Run tests
+        run: vendor/bin/phpunit --no-coverage

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -61,7 +61,7 @@ jobs:
 
       - name: Install dependencies
         run: |
-          composer require "illuminate/support:${{ matrix.laravel }}" "illuminate/contracts:${{ matrix.laravel }}" "illuminate/database:${{ matrix.laravel }}" "orchestra/testbench:${{ matrix.testbench }}" --no-interaction --no-update
+          composer require "illuminate/support:${{ matrix.laravel }}" "illuminate/contracts:${{ matrix.laravel }}" "illuminate/database:${{ matrix.laravel }}" "orchestra/testbench:${{ matrix.testbench }}" --dev --no-interaction --no-update
           composer update --prefer-dist --no-interaction
 
       - name: Run tests

--- a/composer.json
+++ b/composer.json
@@ -23,15 +23,15 @@
   ],
   "require": {
     "php": "^8.1|^8.2",
-    "illuminate/support": "^10.0",
-    "illuminate/contracts": "^10.0",
-    "illuminate/database": "^10.0"
+    "illuminate/support": "^10.0|^11.0|^12.0",
+    "illuminate/contracts": "^10.0|^11.0|^12.0",
+    "illuminate/database": "^10.0|^11.0|^12.0"
   },
   "require-dev": {
     "larapack/dd": "^1.1",
     "laravel/pint": "^1.17",
-    "orchestra/testbench": "^8.0",
-    "phpunit/phpunit": "^9.3",
+    "orchestra/testbench": "^8.0|^9.0|^10.0",
+    "phpunit/phpunit": "^10.5|^11.5",
     "rector/rector": "^1.2",
     "vimeo/psalm": "^4.0"
   },

--- a/composer.json
+++ b/composer.json
@@ -33,7 +33,7 @@
     "orchestra/testbench": "^8.0|^9.0|^10.0",
     "phpunit/phpunit": "^10.5|^11.5",
     "rector/rector": "^1.2",
-    "vimeo/psalm": "^4.0"
+    "vimeo/psalm": "^6.0"
   },
   "autoload": {
     "psr-4": {

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -1,13 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <phpunit
   bootstrap="vendor/autoload.php"
-  backupGlobals="false"
-  backupStaticAttributes="false"
   colors="true"
-  verbose="true"
-  convertErrorsToExceptions="true"
-  convertNoticesToExceptions="true"
-  convertWarningsToExceptions="true"
   processIsolation="false"
   stopOnFailure="false"
 >
@@ -17,18 +11,11 @@
     </testsuite>
   </testsuites>
 
-  <filter>
-    <whitelist>
+  <source>
+    <include>
       <directory suffix=".php">Source/</directory>
-    </whitelist>
-  </filter>
-
-  <logging>
-    <log
-      type="coverage-html"
-      target="Reports/coverage"
-    />
-  </logging>
+    </include>
+  </source>
 
   <php>
     <env name="DB_DRIVER" value="sqlite"/>


### PR DESCRIPTION
## Summary
- Widen `illuminate/*` constraints to `^10.0|^11.0|^12.0`
- Update dev deps: `orchestra/testbench` `^8.0|^9.0|^10.0`, `phpunit/phpunit` `^10.5|^11.5`
- Modernize `phpunit.xml.dist` for PHPUnit 10+ (remove deprecated attributes, `<filter>` → `<source>`)
- Add GitHub Actions workflow with explicit include matrix covering all valid PHP × Laravel combinations

## Test plan
- [ ] CI passes on all 9 matrix entries
- [ ] Verify no regressions on Laravel 10 / PHP 8.1 (lowest supported combo)
- [ ] Verify Laravel 12 / PHP 8.4 (highest supported combo)